### PR TITLE
Add tasks to enable/disable shorewall autostart

### DIFF
--- a/tasks/configs.yml
+++ b/tasks/configs.yml
@@ -24,3 +24,8 @@
     dest: "{{ shorewall_configs_dir }}/interfaces"
   notify:
     - shorewall restart
+
+- name: Configure shorewall service autostart
+  service:
+    name:  shorewall
+    enabled: "{{ 'yes' if shorewall_startup == 1 else 'no' }}"

--- a/tasks/configsipv6.yml
+++ b/tasks/configsipv6.yml
@@ -27,3 +27,9 @@
   notify:
     - shorewall6 restart
   when: shorewall6_enable
+
+- name: Configure shorewall6 service autostart
+  service:
+    name:  shorewall6
+    enabled: "{{ 'yes' if shorewall_startup == 1 else 'no' }}"
+  when: shorewall6_enable


### PR DESCRIPTION
This PR adds support for enabling/disabling shorewall services autostart.

For this the `shorewall_startup` variable already used for setting the debian specific startup setting is reused i.e.,
if `shorewall_startup == 1` then autostart is enabled otherwise it is disabled.